### PR TITLE
Definition structure interfaces objects sdk module messenger

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -96,7 +96,7 @@
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
      "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
      "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index.ts. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/packages/messenger/src/client/RequestProvider.ts
+++ b/packages/messenger/src/client/RequestProvider.ts
@@ -1,0 +1,73 @@
+import { RequestOptions, RequestData } from "../interfaces/RequestInterfaces";
+
+export class RequestProvider {
+
+  private static requestOptions: RequestOptions = {
+    url: 'https://graph.facebook.com/v3.1/',
+    qs: {
+      access_token: undefined,
+    },
+    method: undefined,
+  };
+
+  /* istanbul ignore next line */
+  private constructor() {}
+
+  public static getRequestOptions(): RequestOptions {
+    return <RequestOptions>JSON.parse(JSON.stringify(RequestProvider.requestOptions));
+  }
+
+  public static sendMessage(options: RequestOptions, requestData: RequestData, cb?: Function) {
+    options.qs.access_token = requestData.token;
+
+    if (requestData.hasOwnProperty('proxy')) {
+      options.proxy = requestData.proxy;
+    }
+
+    if (typeof cb !== 'function') {
+      return new Promise((resolve, reject) => {
+        request(options, (err, _res, body) => {
+          if (err) {
+            reject(err);
+          } else {
+            if (!((typeof body === 'object' && !Array.isArray(body) && body !== null))) {
+              const bodyObject = JSON.parse(body);
+              if (bodyObject.error) {
+                reject(bodyObject.error.message);
+              } else {
+                resolve(bodyObject);
+              }
+            } else {
+              resolve(body);
+            }
+          }
+        });
+      });
+      // tslint:disable-next-line
+    } else {
+      request(options, (err, _res, body) => {
+        if (err) return cb(err);
+        if (body.error) return cb(body.error);
+        cb(null, body);
+      });
+      return Promise.resolve();
+    }
+  }
+
+  public static getProxyData(requestData: RequestData, proxyData?: ProxyData) {
+    if (proxyData) {
+      if (Object.prototype.toString.call(proxyData) === '[object Object]'
+        && proxyData.hasOwnProperty('hostname')
+        && proxyData.hasOwnProperty('port')) {
+        if (proxyData.hostname.indexOf('http') === 0) {
+          requestData.proxy = `${proxyData.hostname}:${proxyData.port}`;
+        } else {
+          requestData.proxy = `http://${proxyData.hostname}:${proxyData.port}`;
+        }
+      } else {
+        throw new Error('Invalid Proxy object given, expected hostname and port');
+      }
+    }
+    return requestData;
+  }
+}

--- a/packages/messenger/src/enums/index.ts
+++ b/packages/messenger/src/enums/index.ts
@@ -1,0 +1,67 @@
+export enum QUICK_REPLY_TYPE {
+  TEXT = 'text',
+  LOCATION = 'location',
+  USER_PHONE_NUMBER = 'user_phone_number',
+  USER_EMAIL = 'user_email',
+}
+
+export enum LIST_TOP_ELEMENT_STYLE {
+  LARGE = 'large',
+  COMPACT = 'compact',
+}
+
+export enum BUTTON_PAYMENT_TYPE {
+  FIXED_AMOUNT,
+  FLEXIBLE_AMOUNT,
+}
+
+export enum ATTACHMENT_TYPE {
+  IMAGE = 'image',
+  AUDIO = 'audio',
+  VIDEO = 'video',
+  FILE = 'file',
+  TEMPLATE = 'template',
+  FALLBACK = 'fallback',
+}
+export enum MESSAGE_TEMPLATE_TYPE {
+  BUTTON = 'button',
+  LIST = 'list',
+  GENERIC = 'generic',
+  MEDIA = 'media',
+  OPEN_GRAPH = 'open_graph',
+  RECEIPT = 'receipt',
+  AIRLINE_BOARDING_PASS = 'airline_boardingpass',
+  AIRLINE_CHECKIN = 'airline_checkin',
+  AIRLINE_ITINERARY = 'airline_itinerary',
+  AIRLINE_UPDATE = 'airline_update',
+}
+
+export enum BUTTON_TYPE {
+  BUY = 'payment',
+  CALL = 'phone_number',
+  GAME_PLAY = 'game_play',
+  LOG_IN = 'account_link',
+  LOG_OUT = 'account_unlink',
+  POSTBACK = 'postback',
+  SHARE = 'element_share',
+  URL = 'web_url',
+}
+
+export enum MEDIA_TYPE {
+  IMAGE = 'image',
+  VIDEO = 'video',
+}
+
+export enum AIRLINE_TRAVEL_CLASS {
+  ECONOMY = 'economy',
+  BUSINESS = 'business',
+  FIRST_CLASS = 'first_class',
+}
+
+export enum REFERER_SOURCE {
+  MESSENGER_CODE = 'MESSENGER_CODE',
+  DISCOVER_TAB = 'DISCOVER_TAB',
+  ADS = 'ADS',
+  SHORTLINK = 'SHORTLINK',
+  CUSTOMER_CHAT_PLUGIN = 'CUSTOMER_CHAT_PLUGIN',
+}

--- a/packages/messenger/src/interfaces/ButtonInterfaces.ts
+++ b/packages/messenger/src/interfaces/ButtonInterfaces.ts
@@ -1,0 +1,113 @@
+import { BUTTON_PAYMENT_TYPE, BUTTON_TYPE } from '../enums';
+import { IGenericTemplate } from './TemplateComponentInterfaces';
+
+/**
+ * Base type for all buttons.
+ */
+export interface IButton {
+  type: BUTTON_TYPE;
+}
+
+/**
+ * Represents a URL Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/url
+ */
+export interface IURLButton extends IButton {
+  url: string;
+  title: string;
+  messenger_extensions?: boolean;
+  fallback_url?: string;
+  webview_height_ratio?: string;
+  webview_share_button?: string;
+}
+
+/**
+ * Represents a Postback Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/postback
+ */
+export interface IPostbackButton extends IButton {
+  title: string;
+  payload: string;
+}
+
+/**
+ * Represents a Share Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/share
+ */
+export interface IShareButton extends IButton {
+  share_contents?: IGenericTemplate;
+}
+
+export interface IPaymentSummary {
+  currency: string;
+  is_test_payment?: boolean;
+  payment_type: BUTTON_PAYMENT_TYPE;
+  merchant_name: string;
+  requested_user_info: string[];
+  price_list: [{
+    label: string,
+    amount: string,
+  }];
+}
+/**
+ * Represents a Buy Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/buy
+ */
+export interface IBuyButton extends IButton {
+  title: string;
+  payload: string;
+  payment_summary: IPaymentSummary;
+}
+
+/**
+ * Represents a Call Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/call
+ */
+export interface ICallButton extends IButton {
+  title: string;
+  payload: string;
+}
+
+/**
+ * Represents a LogIn Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/login
+ */
+export interface ILogInButton extends IButton {
+  url: string;
+}
+
+/**
+ * Represents a LogOut Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/logout
+ */
+export interface ILogOutButton extends IButton {
+}
+
+/**
+ * Represents a GamePlay Button. Used to represent shape of Facebook API object. Type returned by builder and exposed to users to create
+ * own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/buttons/game-play
+ */
+export interface IGamePlayButton extends IButton {
+  title: string;
+  payload?: string;
+  game_metadata?: {
+    player_id?: string,
+    context_id?: string,
+  };
+}

--- a/packages/messenger/src/interfaces/ClientInterfaces.ts
+++ b/packages/messenger/src/interfaces/ClientInterfaces.ts
@@ -1,0 +1,17 @@
+import { ATTACHMENT_TYPE } from '../enums';
+
+export interface ClientMessage {
+  message?: MessagePayload;
+  sender_action?: string;
+}
+
+export interface AttachmentPayload {
+  type: ATTACHMENT_TYPE;
+  payload: Object;
+}
+
+export interface MessagePayload {
+  text?: string;
+  // quick_replies?: IQuickReply[];
+  attachment?: AttachmentPayload;
+}

--- a/packages/messenger/src/interfaces/MessageStructureInterfaces.ts
+++ b/packages/messenger/src/interfaces/MessageStructureInterfaces.ts
@@ -1,0 +1,295 @@
+/**
+ * Interfaces representing webhook events messages received from Messenger platform.
+ * Full documentation available at https://developers.facebook.com/docs/messenger-platform/reference/webhook-events
+ */
+import { ATTACHMENT_TYPE, REFERER_SOURCE } from '../enums';
+
+export interface MessengerMessagePayload {
+  object: string;
+  entry: MessengerMessagePayloadEntry[];
+}
+
+export interface MessengerMessagePayloadEntry {
+  id: string;
+  time: number;
+  messaging: MessengerMessagePayloadMessagingEntry[];
+}
+
+/**
+ * Encompassing payload containing all variations of payload types. Only one of optional types present in every payload.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadMessagingEntry {
+  sender: {
+    id: string,
+  };
+  recipient: {
+    id: string,
+  };
+  timestamp: number;
+  message?: MessengerMessagePayloadMessageEntry;
+  account_linking?: MessengerMessagePayloadAccountLinking;
+  checkout_update?: MessengerMessagePayloadCheckoutUpdate;
+  delivery?: MessengerMessagePayloadDelivery;
+  game_play?: MessengerMessagePayloadGame;
+  pass_thread_control?: MessengerMessageHandover;
+  optin?: MessengerMessageOptin;
+  payment?: MessengerMessagePayloadPayment;
+  'policy-enforcement'?: MessengerMessagePayloadPolicyEnforcement;
+  postback?: MessengerMessagePayloadPostback;
+  payment_pre_checkout?: MessengerMessagePayloadPreCheckout;
+  read?: MessengerMessagePayloadRead;
+  referral?: MessengerMessagePayloadReferral;
+  standby?: MessengerMessagePayloadStandbyChannel[];
+}
+
+/**
+ * Represents a message incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadMessageEntry {
+  mid: string;
+  is_echo?: boolean;
+  app_id?: number;
+  metadata?: string;
+  seq?: string;
+  text?: string;
+  attachments?: (MessengerMessagePayloadAttachments | MessengerMessagePayloadAttachmentsFallback)[];
+  quick_reply?: {
+    payload: string,
+  };
+}
+
+/**
+ * Represents a message multimedia attachment incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadAttachments {
+  type: ATTACHMENT_TYPE;
+  payload: MessengerMessagePayloadAttachmentMultimedia | MessengerMessagePayloadAttachmentLocation;
+}
+
+/**
+ * Represents a message multimedia attachment payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadAttachmentMultimedia {
+  url: string;
+}
+
+/**
+ * Represents a message geolocation attachment payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadAttachmentLocation {
+  'coordinates.lat': string;
+  'coordinates.long': string;
+}
+
+/**
+ * Represents a message fallback attachment payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages
+ */
+export interface MessengerMessagePayloadAttachmentsFallback {
+  type: ATTACHMENT_TYPE;
+  payload: null;
+  url: string;
+  title: string;
+}
+
+/**
+ * Represents a postback payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/postback-received
+ */
+export interface MessengerMessagePayloadPostback {
+  title: string;
+  payload: string;
+  referral: MessengerMessagePayloadReferral;
+}
+
+/**
+ * Represents a postback payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/referral
+ */
+export interface MessengerMessagePayloadReferral {
+  ref?: string;
+  source: REFERER_SOURCE;
+  type: string;
+  ad_id?: string;
+  referer_uri?: string;
+}
+
+/**
+ * Represents a read payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-read
+ */
+export interface MessengerMessagePayloadRead {
+  watermark: string;
+  seq: string;
+}
+
+/**
+ * Represents a delivery payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-read
+ */
+export interface MessengerMessagePayloadDelivery {
+  mids: string[];
+  watermark: number;
+  seq: number;
+}
+
+/**
+ * Represents a standby channel payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/standby
+ */
+export interface MessengerMessagePayloadStandbyChannel {
+  sender: {
+    id: string,
+  };
+  recipient: {
+    id: string,
+  };
+  message?: MessengerMessagePayloadMessageEntry;
+  postback?: MessengerMessagePayloadPostback;
+  read?: MessengerMessagePayloadRead;
+  delivery?: MessengerMessagePayloadDelivery;
+}
+
+/**
+ * Represents a payment pre-checkout channel payload incoming from Messenger.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_pre_checkouts
+ */
+export interface MessengerMessagePayloadPreCheckout {
+  payload: string;
+  amount: {
+    currency: string,
+    amount: string,
+  };
+  requested_user_info: {
+    shipping_address: MessengerMessagePayloadPaymentShipping
+    contact_name: string,
+  };
+}
+
+/**
+ * Represents a payment shipping info sub-payload incoming from Messenger.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_pre_checkouts
+ */
+export interface MessengerMessagePayloadPaymentShipping {
+  name?: string;
+  id?: string;
+  street_1: string;
+  street_2: string;
+  city: string;
+  state: string;
+  country: string;
+  postal_code: string;
+}
+
+/**
+ * Represents an account linking payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/account-linking
+ */
+export interface MessengerMessagePayloadAccountLinking {
+  status: string;
+  authorization_code: string;
+}
+
+/**
+ * Represents a payment checkout update payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/checkout-update
+ */
+export interface MessengerMessagePayloadCheckoutUpdate {
+  payload: string;
+  shipping_address: MessengerMessagePayloadPaymentShipping;
+}
+
+/**
+ * Represents a game play payload incoming from Messenger.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_game_plays/
+ */
+export interface MessengerMessagePayloadGame {
+  game_id: string;
+  player_id: string;
+  context_type: string;
+  context_id: string;
+  score: number;
+  payload: string;
+}
+
+/**
+ * Represents a handover payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.Messenger.com/docs/messenger-platform/reference/webhook-events/messaging_handovers
+ */
+export interface MessengerMessageHandover {
+  new_owner_app_id: string;
+  metadata: string;
+}
+
+/**
+ * Represents a optin payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_optins
+ */
+export interface MessengerMessageOptin {
+  ref: string;
+  user_ref: string;
+}
+
+/**
+ * Represents a policy enforcement payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/policy-enforcement
+ */
+export interface MessengerMessagePayloadPolicyEnforcement {
+  action: string;
+  reason: string;
+}
+
+/**
+ * Represents a payment payload incoming from Messenger.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/webhook-reference/payment
+ */
+export interface MessengerMessagePayloadPayment {
+  requested_user_info: {
+    shipping_address: MessengerMessagePayloadPaymentShipping
+    contact_name: string,
+    contact_email: string,
+    contact_phone: string,
+  };
+  payment_credential: {
+    provider_type: string,
+    charge_id: string,
+    fb_payment_id: string
+    tokenized_card?: string,
+    tokenized_cvv?: string,
+    token_expiry_month?: string,
+    token_expiry_year?: string,
+  };
+  amount: {
+    currency: string,
+    amount: string,
+  };
+  shipping_option_id: string;
+}

--- a/packages/messenger/src/interfaces/RequestInterfaces.ts
+++ b/packages/messenger/src/interfaces/RequestInterfaces.ts
@@ -1,0 +1,16 @@
+
+export interface RequestOptions {
+  url: string;
+  qs: {
+    access_token?: string,
+    fields?: string,
+  };
+  method?: string;
+  proxy?: Object;
+  // json?: PageSettings | PagePost | ClientMessage;
+}
+
+export interface RequestData {
+  token: string;
+  proxy?: string;
+}

--- a/packages/messenger/src/interfaces/TemplateComponentInterfaces.ts
+++ b/packages/messenger/src/interfaces/TemplateComponentInterfaces.ts
@@ -1,0 +1,443 @@
+import { IButton } from './ButtonInterfaces';
+import { AIRLINE_TRAVEL_CLASS, LIST_TOP_ELEMENT_STYLE, MEDIA_TYPE, MESSAGE_TEMPLATE_TYPE } from '../enums';
+
+/**
+ * Represents a Quick Reply. Used to represent shape of Facebook API object. Type returned by builder and exposed to
+ * users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/send-api/quick-replies
+ */
+export interface IMessageTemplate {
+  template_type: MESSAGE_TEMPLATE_TYPE;
+}
+
+/**
+ * Represents a IButton Template. Used to represent shape of Facebook API object. Type returned by builder and exposed
+ * to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/button
+ */
+export interface IButtonTemplate extends IMessageTemplate {
+  text?: string;
+  buttons: IButton[];
+  sharable?: boolean;
+}
+
+/**
+ * Represents a Generic Template element. Used to represent shape of Facebook API object. Type returned by builder and
+ * exposed to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/generic#elements
+ */
+export interface IGenericTemplateElement {
+  title: string;
+  subtitle?: string;
+  image_url?: string;
+  default_action?: {
+    type: string
+    url: string,
+    messenger_extensions?: boolean,
+    fallback_url?: string,
+    webview_height_ratio?: string,
+    webview_share_button?: string,
+  };
+  buttons: IButton[];
+}
+
+/**
+ * Represents a Generic Template. Used to represent shape of Facebook API object. Type returned by builder and exposed
+ * to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/generic
+ */
+export interface IGenericTemplate extends IMessageTemplate {
+  image_aspect_ratio?: string;
+  elements: IGenericTemplateElement[];
+}
+
+/**
+ * Represents a List Template. Used to represent shape of Facebook API object. Type returned by builder and exposed to
+ * users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/list
+ */
+export interface IListTemplate extends IMessageTemplate {
+  top_element_style?: LIST_TOP_ELEMENT_STYLE;
+  buttons?: IButton[];
+  elements: IGenericTemplateElement[];
+  sharable?: boolean;
+}
+
+/**
+ * Represents a Media Template element. Used to represent shape of Facebook API object. Type returned by builder and
+ * exposed to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/media#elements
+ */
+export interface IMediaTemplateElement {
+  media_type: MEDIA_TYPE;
+  attachment_id?: string;
+  url?: string;
+  buttons: IButton[];
+}
+
+/**
+ * Represents a Media Template. Used to represent shape of Facebook API object. Type returned by builder and exposed to
+ * users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/media
+ */
+export interface IMediaTemplate extends IMessageTemplate {
+  elements: IMediaTemplateElement[];
+  sharable?: boolean;
+}
+
+/**
+ * Represents an Open Graph element. Used to represent shape of Facebook API object. Type returned by builder and
+ * exposed to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/open-graph#elements
+ */
+export interface IOpenGraphElement {
+  url: string;
+  buttons: IButton[];
+}
+
+/**
+ * Represents an Open Graph. Used to represent shape of Facebook API object. Type returned by builder and exposed to
+ * users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/open-graph
+ */
+export interface IOpenGraphTemplate extends IMessageTemplate {
+  elements: IOpenGraphElement[];
+}
+
+/**
+ * Represents a Receipt Template address property. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/receipt#address
+ */
+export interface IReceiptAddressProperty {
+  street_1: string;
+  street_2?: string;
+  city: string;
+  postal_code: string;
+  state: string;
+  country: string;
+}
+
+/**
+ * Represents a Receipt Template summary property. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/receipt#summary
+ */
+export interface IReceiptSummaryProperty {
+  subtotal?: number;
+  shipping_cost?: number;
+  total_tax?: number;
+  total_cost: number;
+}
+
+/**
+ * Represents a Receipt Template adjustment property. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/receipt#adjustments
+ */
+export interface IReceiptAdjustmentProperty {
+  name: string;
+  amount: number;
+}
+
+/**
+ * Represents a Receipt Template element. Used to represent shape of Facebook API object. Type returned by builder and
+ * exposed to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/receipt#elements
+ */
+export interface IReceiptElements {
+  title: string;
+  subtitle?: string;
+  quantity?: number;
+  price: number;
+  currency?: string;
+  image_url?: string;
+}
+
+/**
+ * Represents a Receipt Template. Used to represent shape of Facebook API object. Type returned by builder and exposed
+ * to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/receipt
+ */
+export interface IReceiptTemplate extends IMessageTemplate {
+  sharable?: boolean;
+  recipient_name: string;
+  merchant_name?: string;
+  order_number: string;
+  currency: string;
+  payment_method: string;
+  timestamp?: string;
+  adjustments?: IReceiptAdjustmentProperty;
+  summary: IReceiptSummaryProperty;
+  address?: IReceiptAddressProperty;
+  elements?: IReceiptElements;
+}
+
+/**
+ * Represents an Airline Boarding Pass Template auxiliary field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#auxiliary_field
+ */
+export interface IBoardingPassAuxiliaryField {
+  label: string;
+  value: string;
+}
+
+/**
+ * Represents an Airline Boarding Pass Template secondary field. Used to represent shape of Facebook API object.
+ * Type returned by builder and exposed to users to create own object of proper shape if desired taking into account
+ * content restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#secondary_field
+ */
+export interface IBoardingPassSecondaryField {
+  label: string;
+  value: string;
+}
+
+/**
+ * Represents an Airline * Template flight schedule. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#flight_schedule
+ */
+export interface IFlightInfoFlightSchedule {
+  boarding_time?: string;
+  departuire_time: string;
+  arrival_time?: string;
+}
+
+/**
+ * Represents an Airline * Template departure airport field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#departure_airport
+ */
+export interface IFlightInfoDepartureAirport {
+  airport_code: string;
+  city: string;
+  terminal?: string;
+  gate?: string;
+}
+
+/**
+ * Represents an Airline * Template arrival airport field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#arrival_airport
+ */
+export interface IFlightInfoArrivalAirport {
+  airport_code: string;
+  city: string;
+  terminal?: string;
+  gate?: string;
+}
+
+/**
+ * Represents an Airline * Template flight info field. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#flight_info
+ */
+export interface IBoardingPassFlightInfo {
+  flight_number: string;
+  departure_airport: IFlightInfoDepartureAirport;
+  arrival_airport: IFlightInfoArrivalAirport;
+  flight_schedule: IFlightInfoFlightSchedule;
+}
+
+/**
+ * Represents a n Airline Boarding Pass Template boarding pass element. Used to represent shape of Facebook API object.
+ * Type returned by builder and exposed to users to create own object of proper shape if desired taking into account
+ * content restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass#boarding_pass
+ */
+export interface IBoardingPass {
+  passenger_name: string;
+  pnr_number: string;
+  travel_class?: string;
+  seat?: string;
+  auxiliary_fields?: IBoardingPassAuxiliaryField;
+  secondary_fields?: IBoardingPassSecondaryField;
+  logo_image_url: string;
+  header_image_url?: string;
+  header_text_field?: string;
+  qr_code?: string;
+  barcode_image_url?: string;
+  above_bar_code_image_url: string;
+  flight_info: IBoardingPassFlightInfo;
+}
+
+/**
+ * Represents an Airline Boarding Pass Template. Used to represent shape of Facebook API object. Type returned by builder
+ * and exposed to users to create own object of proper shape if desired taking into account content restrictions for the
+ * object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-boarding-pass
+ */
+export interface IAirlineBoardingPassTemplate extends IMessageTemplate {
+  intro_message: string;
+  locale: string;
+  theme_color?: string;
+  boarding_pass: IBoardingPass[];
+}
+
+/**
+ * Represents an Airline CheckIn Template. Used to represent shape of Facebook API object. Type returned by builder and
+ * exposed to users to create own object of proper shape if desired taking into account content restrictions for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/airline-checkin
+ */
+export interface IAirlineCheckInTemplate extends IMessageTemplate {
+  intro_message: string;
+  locale: string;
+  pnr_number?: string;
+  checkin_url: string;
+  flight_info: IBoardingPassFlightInfo[];
+}
+
+/**
+ * Represents an Airline Itinerary Template passenger info field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary#passenger_info
+ */
+export interface IAirlineItineraryPassengerInfo {
+  passenger_id: string;
+  ticket_number?: string;
+  name: string;
+}
+
+/**
+ * Represents an Airline Itinerary Template flight info field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary#flight_info
+ */
+export interface IAirlineItineraryFlightInfo {
+  connection_id: string;
+  segment_id: string;
+  flight_number: string;
+  aircraft_type?: string;
+  departure_airport: IFlightInfoDepartureAirport;
+  arrival_airport: IFlightInfoArrivalAirport;
+  flight_schedule: IFlightInfoFlightSchedule;
+  travel_class: AIRLINE_TRAVEL_CLASS;
+}
+
+/**
+ * Represents an Airline Itinerary Template product info field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary#product_info
+ */
+export interface IAirlinePassengerProductInfo {
+  title: string;
+  value: string;
+}
+
+/**
+ * Represents an Airline Itinerary Template passenger segment field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary#passenger_segment_info
+ */
+export interface IAirlineItineraryPassengerSegment {
+  segment_id: string;
+  passenger_id: string;
+  seat: string;
+  seat_type: string;
+  product_info?: IAirlinePassengerProductInfo[];
+}
+
+/**
+ * Represents an Airline Itinerary Template price info field. Used to represent shape of Facebook API object. Type
+ * returned by builder and exposed to users to create own object of proper shape if desired taking into account content
+ * restrictions for the object.
+ *
+ * Check link for content restrictions:
+ * https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary#price_info
+ */
+export interface IAirlineItineraryPriceInfo {
+  title: string;
+  amount: number;
+  currency?: string;
+}
+
+/**
+ * Represents an Airline Itinerary Template. Used to represent shape of Facebook API object. Type returned by builder
+ * and exposed to users to create own object of proper shape if desired taking into account content restrictions for the
+ * object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/airline-itinerary
+ */
+export interface IAirlineItineraryTemplate extends IMessageTemplate {
+  intro_message: string;
+  locale: string;
+  theme_color?: string;
+  pnr_number: string;
+  passenger_info: IAirlineItineraryPassengerInfo[];
+  flight_info: IAirlineItineraryFlightInfo[];
+  passenger_segment_info: IAirlineItineraryPassengerSegment[];
+  price_info?: IAirlineItineraryPriceInfo[];
+  base_price?: number;
+  tax?: number;
+  total_price: number;
+  currency: string;
+}
+
+/**
+ * Represents an Airline Flight Update Template. Used to represent shape of Facebook API object. Type returned by
+ * builder and exposed to users to create own object of proper shape if desired taking into account content restrictions
+ * for the object.
+ *
+ * Check link for content restrictions: https://developers.facebook.com/docs/messenger-platform/reference/template/airline-flight-update
+ */
+export interface IAirlineFlightUpdateTemplate extends IMessageTemplate {
+  intro_message: string;
+  theme_color?: string;
+  update_type: string;
+  locale: string;
+  pnr_number?: string;
+  update_flight_info: IBoardingPassFlightInfo;
+}

--- a/packages/messenger/src/interfaces/index.ts
+++ b/packages/messenger/src/interfaces/index.ts
@@ -1,0 +1,5 @@
+export * from "./ButtonInterfaces";
+export * from "./ClientInterfaces";
+export * from "./MessageStructureInterfaces";
+export * from "./RequestInterfaces";
+export * from "./TemplateComponentInterfaces";

--- a/packages/messenger/src/serializers/MessengerMessageSerializer.ts
+++ b/packages/messenger/src/serializers/MessengerMessageSerializer.ts
@@ -1,0 +1,38 @@
+import { MessengerMessagePayload, MessengerMessagePayloadMessageEntry } from '../interfaces/MessageStructureInterfaces';
+
+export class MessengerMessageSerializer {
+  /**
+   * Parse messenger message to platform received
+   * @param {MessengerMessagePayload} payload data message serializer
+   */
+  public static parse(payload: MessengerMessagePayload): MessengerMessagePayloadMessageEntry[] {
+    if(this.isMessagePayload(payload)) {
+      return this.flattenPayload(payload.entry);
+    }
+
+    throw new Error('Invalid/Unknown Facebook Message Event.');
+  }
+
+  /**
+   * Validate message payload serializer
+   * @param {MessengerMessagePayload} payload data message serializer
+   * @private
+   */
+  private static isMessagePayload(payload: MessengerMessagePayload) {
+    return payload.hasOwnProperty('object') && payload.object === 'page' && typeof payload.entry !== 'undefined';
+  }
+
+  /**
+   * Flatten payload messenger message to serializer
+   * @param {Array} payload data message serializer
+   * @private
+   */
+  private static flattenPayload(payload: any[]): MessengerMessagePayloadMessageEntry[] {
+    return payload.reduce((flat, toFlatten) => {
+
+      return flat.concat(Array.isArray(toFlatten) ? MessengerMessageSerializer.flattenPayload(toFlatten) :
+        Array.isArray(toFlatten.messaging) ? MessengerMessageSerializer.flattenPayload(toFlatten.messaging) : toFlatten);
+
+    }, []);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,7 +97,7 @@
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index.ts. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */


### PR DESCRIPTION
Definition interfaces to use in sdk components and functionals. Specification to messenger assets buttons, clients, structures and templates.

```ts
export interface ClientMessage {
  message?: MessagePayload;
  sender_action?: string;
}

export interface AttachmentPayload {
  type: ATTACHMENT_TYPE;
  payload: Object;
}

export interface MessagePayload {
  text?: string;
  // quick_replies?: IQuickReply[];
  attachment?: AttachmentPayload;
}
```